### PR TITLE
Extend math onto Quaternion, fix tests that should have broken

### DIFF
--- a/lib/quaternion.rb
+++ b/lib/quaternion.rb
@@ -8,6 +8,7 @@ require "#{root_dir}/lib/quaternion/numeric"
 # Class for Quaternion calculation.
 class Quaternion
   include Math
+  extend Math
 
   ##
   # Returns an instance of Quaternion for rotateion aroud +axis+ with angle

--- a/test/test_quaternion.rb
+++ b/test/test_quaternion.rb
@@ -1,9 +1,8 @@
 require "#{__dir__}/minitest_helper"
 
-include Math
-
 class TestQuaternion < Minitest::Test
   include MinitestHelper
+  include Math
 
   def setup
     @q = Quaternion.new(1.0, 2.0, 3.0, 4.0)


### PR DESCRIPTION
The tests include Math in main, which includes it into Object,
making it available to anything that inherits from Object.

This causes singleton methods like Quaternion.rotation to inherit the methods
in the test environment, but not in other environments.

This patch moves the inclusion into the test,
so that it doesn't affect the global namespace,
and then makes the methods available to Quaternion by extending Math onto it.
